### PR TITLE
Fix duplicate TOC operator constant

### DIFF
--- a/py_train_graph/parse.py
+++ b/py_train_graph/parse.py
@@ -38,7 +38,6 @@ _ARR_CSS = "div.arr"
 _DEP_CSS = "div.dep"
 _TOC_OPERATOR_CSS = "div.toc.h3 > div"
 _DEPARTURE_DATE_CSS = "div.header + small"
-_TOC_OPERATOR_CSS = "div.toc.h3 > div"
 _BUS_ICON_CSS = "div.header span.glyphicons-bus"
 
 


### PR DESCRIPTION
## Summary
- remove repeated `_TOC_OPERATOR_CSS` constant definition
- keep single constant definition

## Testing
- `ruff check py_train_graph/parse.py`

------
https://chatgpt.com/codex/tasks/task_e_6878b20710f48322a7f986ef43dc98ba