### PR TITLE
Improve reverse routing and docs, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ On **Windows**, double‑click `launch-train-graph.bat`, or launch via:
 ```
 
 * Allows selection of a json preset file from the `presets` directory (additional preset files can be set up to create new graphs)
-* Saves `graph_<headcodes>_<timestamp>_overview.png` (20 × 10 in, 400 dpi)
-* Saves `graph_<headcodes>_<timestamp>_zoomable.png` (40 × 30 in, 100 dpi)
+* Saves `<route>_<date>_<start-end>_<direction>[_<headcodes>]_overview.png` (20×10 in, 400 dpi)
+* Saves `<route>_<date>_<start-end>_<direction>[_<headcodes>]_zoomable.png` (40×30 in, 100 dpi)
 * Opens the interactive plot window (`--no-show` to suppress)
 
 ---
@@ -95,7 +95,7 @@ optional arguments:
   -p, --preset           name or path of a JSON preset (e.g. example_preset.json)
   -l, --locations        list of GB‑NR location codes (required) (e.g. PAD, ACTONW)
   -m, --margin-hours     extend window before (hours, default 0)
-  -s, --custom_schedule  custom CSV schedule (may repeat, e.g. custom_schedule_example.csv)
+  -s, --custom_schedules custom CSV schedule (may repeat, e.g. custom_schedule_example.csv)
   -d, --direction        up | down
   -n, --limit            max RTT services plotted
   --reverse-route        plot distances negative

--- a/py_train_graph/fetch.py
+++ b/py_train_graph/fetch.py
@@ -95,7 +95,11 @@ def get_html(url: str, *, force_refresh: bool = False) -> str:
 
     # Either no cache hit, or user requested fresh, or using requests‑cache
     resp = _SESSION.get(url, timeout=30)
-    resp.raise_for_status()
+    try:
+        resp.raise_for_status()
+    except requests.HTTPError as e:  # pragma: no cover - network failure
+        msg = f"HTTP error fetching {url}: {e}"
+        raise requests.HTTPError(msg) from e
     html = resp.text
 
     if not _REQUESTS_CACHE_OK:

--- a/py_train_graph/utils.py
+++ b/py_train_graph/utils.py
@@ -101,9 +101,12 @@ def generate_rtt_urls(
         One URL per location.
     """
     fmt = "%H:%M"
-    date_obj = _dt.strptime(date, "%Y-%m-%d").date()
-    start_dt = _dt.strptime(start_time, fmt) - timedelta(hours=margin_hours)
-    end_dt = _dt.strptime(end_time, fmt)
+    try:
+        date_obj = _dt.strptime(date, "%Y-%m-%d").date()
+        start_dt = _dt.strptime(start_time, fmt) - timedelta(hours=margin_hours)
+        end_dt = _dt.strptime(end_time, fmt)
+    except ValueError as e:  # pragma: no cover - user error
+        raise ValueError(f"Bad date/time format: {e}") from e
 
     urls: list[str] = []
     end_str = min(end_dt, _dt.strptime("23:59", fmt)).strftime("%H%M")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,54 @@
+import pandas as pd
+import pytest
+
+import py_train_graph.main as main
+import py_train_graph.utils as utils
+import py_train_graph.parse as parse
+
+
+def test_resolve_path(tmp_path):
+    f = tmp_path / "foo.json"
+    f.write_text("{}", encoding="utf-8")
+
+    # existing absolute path
+    assert main._resolve_path(str(f), tmp_path, "json") == f
+
+    # by name within target directory
+    assert main._resolve_path("foo", tmp_path, "json") == f
+
+    # path under subdirectory
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    f2 = sub / "bar.json"
+    f2.write_text("{}", encoding="utf-8")
+    assert main._resolve_path(str(sub / "bar"), tmp_path, "json") == f2
+
+    with pytest.raises(FileNotFoundError):
+        main._resolve_path("missing", tmp_path, "json")
+
+
+def test_parse_manual_csv_errors(tmp_path):
+    distance_map = pd.DataFrame(
+        {"Distance (mi)": [0]}, index=pd.Index(["A"], name="Location")
+    )
+
+    bad = tmp_path / "bad.csv"
+    bad.write_text("Location,Arr\nA,12:00:00\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        parse.parse_manual_csv(bad, distance_map, "2025-01-01")
+
+    unknown = tmp_path / "unknown.csv"
+    unknown.write_text("Location,Arr,Dep\nX,12:00:00,12:01:00\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        parse.parse_manual_csv(unknown, distance_map, "2025-01-01")
+
+
+def test_generate_rtt_urls_cross_midnight():
+    urls = utils.generate_rtt_urls(
+        ["PAD"], "2025-01-02", "01:00", "02:00", margin_hours=2
+    )
+    assert len(urls) == 2
+    assert "2025-01-01" in urls[0]
+    assert "2300" in urls[0]
+    assert "2025-01-02" in urls[1]
+    assert urls[1].endswith("02:00".replace(":", "")) or "0200" in urls[1]


### PR DESCRIPTION
## Summary
- pass reverse_route flag through plotting helpers
- clarify fetch_service_metadata docs
- handle HTTP errors with context
- update README CLI options and output filenames
- add path & URL utilities tests
- improve error messages in parsing functions
- fix README spacing

## Testing
- `ruff check tests/test_utils.py py_train_graph/plot.py py_train_graph/parse.py py_train_graph/utils.py py_train_graph/fetch.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878f524e5d48322b551f400334bf8bb