### PR TITLE
Support grouped custom schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,6 @@ Create a CSV with at least these columns:
 | ...               | …         | …         |
 
 Times **must** be `HH:MM:SS`.  Use the `-s` flag to include one or more files.
-Set `same_custom_colour` to `true` in a preset to draw every custom schedule
-in the same colour.
 
 ---
 
@@ -154,11 +152,15 @@ Save common parameters in a **JSON** file under `presets/`. Example structure:
   "custom_schedules": ["custom_schedule_example.csv"],
   "limit": null,
   "reverse_route": null,
-  "show_plot": null,
-  "same_custom_colour": null
+  "show_plot": null
 }
 
 ```
+When using a preset JSON you can group schedules to share a colour by using
+a nested list, e.g. `[["run1.csv", "run2.csv"], "other.csv"]`.
+Schedules in each inner list are drawn in the same colour. If you provide a
+single list of file paths, each schedule will use a different colour as in
+previous versions.
 
 ---
 

--- a/presets/example_preset.json
+++ b/presets/example_preset.json
@@ -20,6 +20,5 @@
     "custom_schedules": ["custom_schedule_example.csv"],
     "limit": null,
     "reverse_route": null,
-    "show_plot": null,
-    "same_custom_colour": null
+    "show_plot": null
 }

--- a/py_train_graph/config.py
+++ b/py_train_graph/config.py
@@ -42,9 +42,6 @@ OVERVIEW_DPI: int = 400
 REVERSE_ROUTE: bool = True
 USE_CUSTOM: bool = True
 SHOW_PLOT: bool = True
-# If True, all custom schedules share the first colour in
-# the custom schedule colour list in :mod:`py_train_graph.plot`.
-SAME_CUSTOM_COLOUR: bool = False
 
 # ---------------------------------------------------------------------------#
 # External service URLs                                                      #

--- a/py_train_graph/main.py
+++ b/py_train_graph/main.py
@@ -259,8 +259,12 @@ def main(argv: List[str] | None = None) -> None:
 
         override = argparse.ArgumentParser(add_help=False)
         override.add_argument("-n", "--limit", type=int)
-        override.add_argument("--no-show", dest="show_plot", action="store_false", default=None)
-        override.add_argument("--show", dest="show_plot", action="store_true", default=None)
+        override.add_argument(
+            "--no-show", dest="show_plot", action="store_false", default=None
+        )
+        override.add_argument(
+            "--show", dest="show_plot", action="store_true", default=None
+        )
         override_args, _ = override.parse_known_args(remaining)
 
         if override_args.limit is not None:
@@ -277,15 +281,18 @@ def main(argv: List[str] | None = None) -> None:
             end_time=cfg["end_time"],
             margin_hours=cfg.get("margin_hours", 0),
             custom_schedules=[
-                Path(_resolve_path(p, "custom_schedules", "csv"))
-                for p in cfg.get("custom_schedules", [])
+                (
+                    [Path(_resolve_path(p, "custom_schedules", "csv")) for p in group]
+                    if isinstance(group, list)
+                    else Path(_resolve_path(group, "custom_schedules", "csv"))
+                )
+                for group in cfg.get("custom_schedules", [])
             ]
             or None,
             limit=cfg.get("limit"),
             direction=cfg.get("direction"),
             reverse_route=cfg.get("reverse_route"),
             show_plot=cfg["show_plot"],
-            same_custom_colour=cfg.get("same_custom_colour"),
             always_include=cfg.get("always_include", []),
         )
         return
@@ -314,7 +321,6 @@ def main(argv: List[str] | None = None) -> None:
         direction=args.direction,
         reverse_route=args.reverse_route,
         show_plot=args.show_plot,
-        same_custom_colour=None,
         always_include=args.always_include,
     )
 

--- a/tests/test_preset_cli.py
+++ b/tests/test_preset_cli.py
@@ -20,7 +20,6 @@ def test_preset_calls_plot(monkeypatch, tmp_path):
         "limit": 10,
         "reverse_route": None,
         "show_plot": False,
-        "same_custom_colour": True,
     }
     preset_path = tmp_path / "preset.json"
     preset_path.write_text(json.dumps(preset), encoding="utf-8")
@@ -35,7 +34,9 @@ def test_preset_calls_plot(monkeypatch, tmp_path):
     )
     main.main(["--preset", str(preset_path)])
 
-    assert called["same_custom_colour"] is True
+    assert called["custom_schedules"] == [
+        Path("custom_schedules/custom_schedule_example.csv")
+    ]
     assert called["limit"] == 10
     assert called["show_plot"] is False
 
@@ -79,5 +80,3 @@ def test_example_preset_real_run(monkeypatch):
     main.main(["--preset", "example_preset", "-n", "10", "--no-show"])
     duration = time.perf_counter() - start
     assert duration >= 5
-
-


### PR DESCRIPTION
## Summary
- remove same_custom_colour flag
- add support for nested custom_schedules lists so each sub-list shares a colour
- clarify docs and example preset for new behaviour
- adjust tests for default list usage
- move colour grouping note below preset example

## Testing
- `black py_train_graph tests`
- `ruff check py_train_graph tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a58e2e73c83229a7fa64ca7adb6fe