### PR TITLE
Fix matplotlib Tk backend warning in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import matplotlib
+matplotlib.use("Agg", force=True)


### PR DESCRIPTION
## Summary
- ensure matplotlib uses the non-GUI Agg backend during tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68826fb8e40c8322a22887e81945d83e